### PR TITLE
Default handler(calling with out a command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PicoCli.create({
 
 TODO
 
-### `PicoCli.flagHandler`
+### `PicoCli.optionHandler`
 
 TODO
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,10 +152,10 @@ export class PicoCli<GlobOpts extends Options> {
   static create = <T extends Options>(spec: ProgramSpec<T>) =>
     new PicoCli<T>(spec);
 
-  static flagHandler = <T>(handler: OptionHandler<T>): OptionHandler<T> =>
+  static optionHandler = <T>(handler: OptionHandler<T>): OptionHandler<T> =>
     handler;
 
-  static commaSeparatedString = PicoCli.flagHandler<string[]>(
+  static commaSeparatedString = PicoCli.optionHandler<string[]>(
     (val, prev = []) => {
       prev.push(...val.split(","));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,8 @@ export class PicoCli<GlobOpts extends Options> {
     if (wantedCommand === null) {
       if (hasHelp(args)) {
         return this.out(help(this.spec.name, [], this.spec, this.commands));
+      } else if (typeof this.spec.handler === 'function') {
+        return this.spec.handler(parseArguments(args, this.spec.options));
       }
       this.out(help(this.spec.name, [], this.spec, this.commands));
       const msg = `Expected one of known commands: ${Object.keys(

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,8 @@ function resolveCommandName<T extends string>(
   return null;
 }
 const hasHelp = (xs: string[]) => xs.some((x) => x === "--help" || x === "-h");
+const filterNoCascadeOptions = (opts: Options): Options =>
+  Object.fromEntries(Object.entries(opts).filter(([_, v]) => !v.noCascade));
 
 export class PicoCli<GlobOpts extends Options> {
   commands: Record<string, CommandSpec<any, GlobOpts>> = {};
@@ -125,7 +127,7 @@ export class PicoCli<GlobOpts extends Options> {
     if (wantedCommand === null) {
       if (hasHelp(args)) {
         return this.out(help(this.spec.name, [], this.spec, this.commands));
-      } else if (typeof this.spec.handler === 'function') {
+      } else if (typeof this.spec.handler === "function") {
         return this.spec.handler(parseArguments(args, this.spec.options));
       }
       this.out(help(this.spec.name, [], this.spec, this.commands));
@@ -140,7 +142,7 @@ export class PicoCli<GlobOpts extends Options> {
 
     const command = this.commands[wantedCommand];
     const params = parseArguments(rest, {
-      ...("options" in this.spec && this.spec.options),
+      ...filterNoCascadeOptions(this.spec?.options ?? {}),
       ...command.options,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type OptionSpec = {
   description: string;
   handler: OptionHandler;
   required?: true;
+  noCascade?: true;
 };
 export type Options = {
   [optionName: string]: OptionSpec;
@@ -25,13 +26,19 @@ export type OptionsToParams<T extends Options> = {
   [K in keyof T]: OptReturnType<T[K]>;
 } & { _: string[] };
 
+export type OnlyCascadingOptions<T extends Options> = {
+  [K in keyof T]: T[K]["noCascade"] extends true ? never : K;
+}[keyof T];
+
 type AllOptionsToParams<
   CmdOpts extends Options | void,
   GlobOpts extends Options | void,
 > = { _: string[] } & (CmdOpts extends Options
   ? GlobOpts extends Options
     ? {
-        [K in keyof GlobOpts | keyof CmdOpts]: K extends keyof CmdOpts
+        [K in
+          | OnlyCascadingOptions<GlobOpts>
+          | keyof CmdOpts]: K extends keyof CmdOpts
           ? OptReturnType<CmdOpts[K]>
           : K extends keyof GlobOpts
           ? OptReturnType<GlobOpts[K]>

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,4 +69,9 @@ export type ProgramSpec<T extends Options> = {
   options: T;
   /** Used in generated help */
   description: string;
+  /**
+   * If specified, the cli will call it without checking for subcommands
+   * Otherwise, a help with usage examples is printed
+   */
+  handler?: (params: OptionsToParams<T>) => void | Promise<void>;
 };


### PR DESCRIPTION
This is useful to be used when you can invoke a handler by using root command. See examples below.

This change also makes it easier to use pico for one off scripts that do not require subcommands.

## Single command cli

```typescript
PicoCli.create({
  name: 'single-command',
  description: 'actual description',
  options: {
    opt1: {
      names: ['--opt1'],
      description: 'Option one',
      handler: Boolean,
    },
    opt2: {
      names: ['--opt2'],
      description: 'Option two',
      handler: String,
    },
  },
  handler: console.log, // <-- new default hander for command spec
})
  .run();
```

When called, executes the root handler

```
▲ bun run ./examples/single-command.ts --opt1 --opt2 foo bar
{
  _: [ "bar" ],
  opt1: true,
  opt2: "foo"
}
```

## Example with `yarn`

```typescript
PicoCli.create({
  name: 'yarn',
  description: 'Yarn is a javascript package manager',
  options: {
    ignoreScripts: {
      names: ['--ignore-scripts'],
      description: 'Don’t run npm scripts',
      handler: Boolean,
      noCascade: true,  // <-- new field
    },
    verbose: {
      names: ['--verbose'],
      description: 'Output verbose messages',
      handler: Boolean,
    },
  },
  handler: console.log,
})
  .addCommand('init', {
    description: 'Initialise a new package',
    options: {
      yes: {
        names: ['--yes', '-y'],
        description: 'Skip all prompts',
        handler: Boolean,
      },
    },
    handler: console.log,
  })
  .run();
```

Parses `--ignore-scripts` option when called without a command.

```
▲ bun run ./examples/yarn.ts --verbose --ignore-scripts foo bar
{
  _: [ "foo", "bar" ],
  verbose: true,
  ignoreScripts: true
}
```

Doesn't parse `--ignore-scripts` when called a subcommand because `noCascade` is used for this option.

```
▲ bun run ./examples/yarn.ts init --verbose --ignore-scripts foo bar
{
  _: [ "--ignore-scripts", "foo", "bar" ],
  verbose: true
}
```